### PR TITLE
Docker package: Dockerfile & GHCR Publish CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,60 @@
+name: Build and Publish Docker Image
+
+# Trigger workflow on push or release
+on:
+  push:
+    branches: [ main, docker-package-setup ]
+    # Publish semver tags as releases
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Minimal Dockerfile for Intune Power BI Dashboard
+# This serves as a template and can be modified as needed
+
+# Use a lightweight base image with Python for serving
+FROM python:3.11-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install minimal packages
+RUN pip install --no-cache-dir http.server
+
+# Copy application files
+COPY . /app
+
+# Expose port for HTTP server
+EXPOSE 8000
+
+# Command to serve files (example - customize as needed)
+# For Power BI files, you might want to serve them via a web server
+# or run custom scripts for dashboard generation
+CMD ["python", "-m", "http.server", "8000", "--bind", "0.0.0.0"]
+
+# Alternative examples:
+# CMD ["python", "src/dashboard_generator.py"]
+# CMD ["python", "src/data_processor.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # intune-powerbi-dashboard
 Comprehensive Power BI solution for monitoring Microsoft Intune device compliance, software inventory, and endpoint security
+
+## Docker
+
+This repository includes Docker packaging for easy deployment and distribution of the dashboard.
+
+### Pulling and Running the Image
+
+Pull the latest Docker image from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/a-ariff/intune-powerbi-dashboard:latest
+```
+
+Run the container:
+
+```bash
+docker run -d -p 8000:8000 ghcr.io/a-ariff/intune-powerbi-dashboard:latest
+```
+
+Access the dashboard at `http://localhost:8000`
+
+### Building from Source
+
+Alternatively, build the image locally:
+
+```bash
+git clone https://github.com/a-ariff/intune-powerbi-dashboard.git
+cd intune-powerbi-dashboard
+docker build -t intune-powerbi-dashboard .
+docker run -d -p 8000:8000 intune-powerbi-dashboard
+```
+
+### Customization Note
+
+**Note**: The included `Dockerfile` is a minimal template designed to serve dashboard files via a lightweight HTTP server. This is provided as an example and can be modified as needed to:
+
+- Integrate with specific data sources
+- Add authentication mechanisms
+- Configure custom ports or SSL
+- Include additional dependencies
+- Run custom processing scripts
+
+See the `Dockerfile` and `.github/workflows/docker-publish.yml` for implementation details.


### PR DESCRIPTION
This PR adds Docker packaging support for the Intune Power BI Dashboard project:

## Changes Made

### 1. **Minimal Dockerfile Template** (`Dockerfile`)
- Added lightweight Python Alpine-based container
- Serves dashboard files via built-in HTTP server on port 8000
- Template design allows easy customization for specific use cases
- Includes comments with alternative implementation suggestions

### 2. **GitHub Actions CI/CD Workflow** (`.github/workflows/docker-publish.yml`)
- **Triggers**: Push to main/docker-package-setup, pull requests, releases
- **Registry**: GitHub Container Registry (ghcr.io)
- **Authentication**: Uses GITHUB_TOKEN for secure publishing
- **Features**:
  - Automatic Docker Buildx setup
  - Smart tagging (branch refs, semantic versioning, latest)
  - Build caching for faster builds
  - Proper metadata extraction

### 3. **Documentation Updates** (`README.md`)
- Added comprehensive "Docker" section with:
  - Pull and run instructions from GHCR
  - Local build instructions
  - Usage examples with port mapping
  - **Important customization note** explaining template nature
- Clear examples with copy-paste commands
- Links to implementation files for reference

## Docker Usage

```bash
# Pull and run from GHCR
docker pull ghcr.io/a-ariff/intune-powerbi-dashboard:latest
docker run -d -p 8000:8000 ghcr.io/a-ariff/intune-powerbi-dashboard:latest

# Access at http://localhost:8000
```

## Notes

- The Dockerfile is intentionally minimal and serves as a **template**
- Can be easily modified for specific data sources, authentication, SSL, etc.
- CI workflow will automatically build and publish images on merges
- Follows Docker and GitHub Actions best practices